### PR TITLE
Various minor fixes

### DIFF
--- a/avro_to_python/templates/fields/mapField.j2
+++ b/avro_to_python/templates/fields/mapField.j2
@@ -1,65 +1,66 @@
 {%- block map %}
-    def set_{{name}}(self, values: list) -> None:
+    {#
+        Fix: This change ensures Avro maps are mapped to dict type on Python
+    #}
+    def set_{{name}}(self, values: dict) -> None:
 
-        self.{{name}} = []
-        if isinstance(values, list):
-            for item in values:
-                for key, value in item.items():
+        self.{{name}} = {}
+        if isinstance(values, dict):
+            for key, value in values.items():
 
-                    if not isinstance(key, str):
-                        raise TypeError(
-                            "Keys in map types must be strings!"
-                        )
+                if not isinstance(key, str):
+                    raise TypeError(
+                        "Keys in map types must be strings!"
+                    )
 
-                    {#- handle tons of types without recursion which sucks... -#}
-                    {%- if field.map_type.fieldtype == 'reference' %}
-                    self.{{name}}.append({key: {{field.map_type.reference_name}}(value)})
-                    {%- elif field.map_type.fieldtype == 'primitive'%}
-                    if isinstance(value, {{primitive_type_map[field.map_type.avrotype]}}):
-                        self.{{name}}.append({key: value})
-                    else:
-                        raise TypeError(
-                            "Type for '{{name}}' should be '{{primitive_type_map[field.map_type.avrotype]}}'"
-                        )
-                    {%- elif field.map_type.fieldtype == 'map'%}
-                    sub_array = []
-                    if isinstance(value, list):
-                        for sub_item in value:
-                            for sub_key, sub_value in sub_item.items():
-                                if not isinstance(sub_key, str):
-                                    raise TypeError(
-                                        "keys in map types must be strings"
-                                    )
-                                {%- if field.map_type.map_type.fieldtype == 'reference' %}
-                                sub_array.append({sub_key: {{field.map_type.map_type.reference_name}}(sub_value)})
-                                {%- elif field.map_type.map_type.fieldtype == 'primitive'%}
-                                if isinstance(sub_value, {{primitive_type_map[field.map_type.map_type.avrotype]}}):
-                                    sub_array.append({sub_key: sub_value})
-                                else:
-                                    raise TypeError(
-                                        "Type for '{{name}}' should be '{{primitive_type_map[field.map_type.map_type.avrotype]}}'"
-                                    )
-                                {%- endif %}
-                    self.{{name}}.append({key: sub_array})
-                    {%- elif field.map_type.fieldtype == 'array'%}
-                    sub_array = []
-                    if isinstance(value, list):
-                        for element in value:
-                            {#- handle tons of types which sucks... -#}
-                            {%- if field.map_type.array_item_type.fieldtype == 'reference' %}
-                            sub_array.append({{field.map_type.array_item_type.reference_name}}(element))
-                            {%- elif field.array_item_type.fieldtype == 'primitive'%}
-                            if isinstance(element, {{primitive_type_map[field.map_type.array_item_type.avrotype]}}):
-                                sub_array.append(element)
-                            else:
-                                raise TypeError(
-                                    "Type for '{{name}}' should be '{{primitive_type_map[field.array_item_type.fieldtype]}}'"
-                                )
-                            {%- endif %}
-                    {%- endif %}
+                {#- handle tons of types without recursion which sucks... -#}
+                {%- if field.map_type.fieldtype == 'reference' %}
+                self.{{name}}.append({key: {{field.map_type.reference_name}}(value)})
+                {%- elif field.map_type.fieldtype == 'primitive'%}
+                if isinstance(value, {{primitive_type_map[field.map_type.avrotype]}}):
+                    self.{{name}}[key] = value
+                else:
+                    raise TypeError(
+                        "Type for '{{name}}' should be '{{primitive_type_map[field.map_type.avrotype]}}'"
+                    )
+                {%- elif field.map_type.fieldtype == 'map'%}
+                sub_dict = []
+                if isinstance(value, dict):
+                    for sub_key, sub_value in value.items():
+                        if not isinstance(sub_key, str):
+                            raise TypeError(
+                                "keys in map types must be strings"
+                            )
+                        {%- if field.map_type.map_type.fieldtype == 'reference' %}
+                        sub_dict[sub_key] = {{field.map_type.map_type.reference_name}}(sub_value)
+                        {%- elif field.map_type.map_type.fieldtype == 'primitive'%}
+                        if isinstance(sub_dict, {{primitive_type_map[field.map_type.map_type.avrotype]}}):
+                            sub_dict[sub_key] = sub_value
+                        else:
+                            raise TypeError(
+                                "Type for '{{name}}' should be '{{primitive_type_map[field.map_type.map_type.avrotype]}}'"
+                            )
+                        {%- endif %}
+                self.{{name}}[key] = sub_dict
+                {%- elif field.map_type.fieldtype == 'array'%}
+                sub_array = []
+                if isinstance(value, list):
+                    for element in value:
+                        {#- handle tons of types which sucks... -#}
+                        {%- if field.map_type.array_item_type.fieldtype == 'reference' %}
+                        sub_array.append({{field.map_type.array_item_type.reference_name}}(element))
+                        {%- elif field.array_item_type.fieldtype == 'primitive'%}
+                        if isinstance(element, {{primitive_type_map[field.map_type.array_item_type.avrotype]}}):
+                            sub_array.append(element)
+                        else:
+                            raise TypeError(
+                                "Type for '{{name}}' should be '{{primitive_type_map[field.array_item_type.fieldtype]}}'"
+                            )
+                        {%- endif %}
+                {%- endif %}
         else:
-            raise TypeError("Field '{{name}}' should be type list")
+            raise TypeError("Field '{{name}}' should be type dict")
 
-    def get_{{name}}(self) -> list:
+    def get_{{name}}(self) -> dict:
         return self.{{name}}
 {%- endblock -%}

--- a/avro_to_python/templates/imports/fileImports.j2
+++ b/avro_to_python/templates/imports/fileImports.j2
@@ -1,7 +1,13 @@
 {% block fileimports %}
 {%- if file.imports %}
 {%- for imp in file.imports -%}
-from {{pip_import}}{{imp.namespace}}.{{imp.name}} import {{imp.name}}
+{#
+    Fix: This change along with changes to the import/reference logic fixes the following invalid output:
+    `from com.namespace.className.var_name import var_name`
+    Now results in
+    `from com.namespace import className`
+#}
+from {{pip_import}}{{imp.namespace}} import {{imp.name}}
 {% endfor -%}
 {%- endif -%}
 {% endblock %}

--- a/avro_to_python/utils/avro/files/record.py
+++ b/avro_to_python/utils/avro/files/record.py
@@ -99,5 +99,8 @@ def _record_file(file: File, item: dict, queue: List[dict]) -> None:
 
         file.fields[field.name] = field
         file.imports += references
+        # Fix: Fixes issue where only the very first reference would be added within each file
+        # (because functions downstream only appended a new reference if references was empty
+        references = []
 
     file.imports = dedupe_imports(file.imports)

--- a/avro_to_python/utils/avro/types/reference.py
+++ b/avro_to_python/utils/avro/types/reference.py
@@ -29,7 +29,8 @@ def _reference_type(field: dict, references: list) -> Field:
 
     # should only happen with array field references
     if not reference:
-        namespace, name = split_namespace(f"{field['type']}.{field['name']}")
+        # Fix: Fixes issues where the name of a field was used as its type in the generated Python code
+        namespace, name = split_namespace(f"{field['type']}")
         reference = Reference(name=name, namespace=namespace)
         references.append(reference)
 


### PR DESCRIPTION
Quick fixes for some issues that popped up (WIP). Might not generalize to other schemas. 
**Not intended to be merged as is.**

**Fixes imports:**
```
# previously
from com.namespace.className.var_name import var_name
# with changes
from com.namespace import className
```

**Fixes type hints:**
```
# previously
def set_my_var(self, values: my_var)
def get_my_var(self) -> my_var
# with changes
def set_my_var(self, values: MyVarsClass)
...
```

**Fixes references and imports:**
If a module had a dependency on more than one other generated module it would only contain an import for the first dependency.

**Not fixed:**
Avro `map` type is somehow of type `List[dict]` in the generated code. There's probably a reason to it, but I couldn't think of it yet. I think this could be an issue later on.